### PR TITLE
Use regex return in place of deprecated RegEx.$

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@ var re = require('author-regex');
 module.exports = function(str) {
   var author = re().exec(str);
   return {
-    name: RegExp.$1,
-    email: RegExp.$2,
-    url: RegExp.$3
+    name: author[1] || '',
+    email: author[2] || '',
+    url: author[3] || ''
   };
 };


### PR DESCRIPTION
The use of RegEx.$1-$9 has been deprecated (See [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#RegExp_Properties)). Modified the library to use the return value instead.

I will gladly bump the version number in the pull request if desired.
