### PR TITLE
don't return empty strings for missing properties & support misordered properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,10 @@
 var re = require('author-regex');
 
 module.exports = function(str) {
-  str = emit(str).replace(/(\( *\)|< *>)?/g, '');
+  if (typeof str !== 'string') {
+    throw new TypeError('expected author to be a string');
+  }
+  str = str.replace(/(\( *\)|< *>)?/g, '');
   var author = re().exec(str) || {};
 
   return {

--- a/index.js
+++ b/index.js
@@ -16,13 +16,9 @@ module.exports = function(str) {
   str = str.replace(/(\( *\)|< *>)?/g, '');
   var author = re().exec(str) || {};
 
-  return {
-    name: emit(author[1]),
-    email: emit(author[2]),
-    url: emit(author[3])
-  };
+  var obj = {};
+  if (author[1] && author[1].trim()) obj.name = author[1].trim();
+  if (author[2] && author[2].trim()) obj.email = author[2].trim();
+  if (author[3] && author[3].trim()) obj.url = author[3].trim();
+  return obj;
 };
-
-function emit(str) {
-  return (str == null ? '' : String(str)).trim();
-}

--- a/index.js
+++ b/index.js
@@ -7,18 +7,16 @@
 
 'use strict';
 
-var re = require('author-regex');
-
 module.exports = function(str) {
   if (typeof str !== 'string') {
     throw new TypeError('expected author to be a string');
   }
-  str = str.replace(/(\( *\)|< *>)?/g, '');
-  var author = re().exec(str) || {};
-
+  var name = str.match(/^([^\(<]+)/);
+  var url = str.match(/\(([^\)]+)\)/);
+  var email = str.match(/<([^>]+)>/);
   var obj = {};
-  if (author[1] && author[1].trim()) obj.name = author[1].trim();
-  if (author[2] && author[2].trim()) obj.email = author[2].trim();
-  if (author[3] && author[3].trim()) obj.url = author[3].trim();
+  if (name && name[1].trim()) obj.name = name[1].trim();
+  if (email && email[1].trim()) obj.email = email[1].trim();
+  if (url && url[1].trim()) obj.url = url[1].trim();
   return obj;
 };

--- a/package.json
+++ b/package.json
@@ -19,9 +19,6 @@
   "scripts": {
     "test": "mocha"
   },
-  "dependencies": {
-    "author-regex": "^0.2.1"
-  },
   "devDependencies": {
     "gulp-format-md": "^0.1.7",
     "mocha": "*"

--- a/test.js
+++ b/test.js
@@ -13,7 +13,7 @@ var author = require('./');
 
 describe('author:', function() {
   it('should return empty fields for missing properties', function() {
-    assert.deepEqual(author(''), {name: '', email: '', url: ''});
+    assert.deepEqual(author(''), {});
   });
 
   it('should return a parsed author object', function() {
@@ -32,65 +32,57 @@ describe('author:', function() {
     var fixture = 'Jon Schlinkert (https://github.com/jonschlinkert)';
     assert.deepEqual(
       author(fixture),
-      {
-        name: 'Jon Schlinkert',
-        email: '',
-        url: 'https://github.com/jonschlinkert'
-      }
+      {name: 'Jon Schlinkert', url: 'https://github.com/jonschlinkert'}
     );
   });
 
   it('should handle trailing whitespace', function() {
     assert.deepEqual(
       author('Jon Schlinkert '),
-      {name: 'Jon Schlinkert', email: '', url: ''}
+      {name: 'Jon Schlinkert'}
     );
   });
 
   it('should handle empty url placeholders', function() {
-    assert.deepEqual(author(' ()'), {name: '', email: '', url: ''});
+    assert.deepEqual(author(' ()'), {});
     assert.deepEqual(
       author('Jon Schlinkert ()'),
-      {name: 'Jon Schlinkert', email: '', url: ''}
+      {name: 'Jon Schlinkert'}
     );
     assert.deepEqual(
       author('<jon.schlinkert@sellside.com> ()'),
-      {name: '', email: 'jon.schlinkert@sellside.com', url: ''}
+      {email: 'jon.schlinkert@sellside.com'}
     );
   });
 
   it('should handle empty email placeholders', function() {
-    assert.deepEqual(author('<>'), {name: '', email: '', url: ''});
+    assert.deepEqual(author('<>'), {});
     assert.deepEqual(
       author('Jon Schlinkert <>'),
-      {name: 'Jon Schlinkert', email: '', url: ''}
+      {name: 'Jon Schlinkert'}
     );
     assert.deepEqual(
       author('<> (https://github.com/jonschlinkert)'),
-      {name: '', email: '', url: 'https://github.com/jonschlinkert'}
+      {url: 'https://github.com/jonschlinkert'}
     );
   });
 
   it('should handle empty email and url placeholders', function() {
-    assert.deepEqual(author('<> ()'), {name: '', email: '', url: ''});
+    assert.deepEqual(author('<> ()'), {});
   });
 
   it('should handle missing name property', function() {
     var fixture = '<jon@foo.email> (https://github.com/jonschlinkert)';
     assert.deepEqual(
       author(fixture),
-      {
-        name: '',
-        email: 'jon@foo.email',
-        url: 'https://github.com/jonschlinkert'
-      }
+      {email: 'jon@foo.email', url: 'https://github.com/jonschlinkert'}
     );
   });
 
   it('should return name only', function() {
     assert.deepEqual(
       author('Jon Schlinkert'),
-      {name: 'Jon Schlinkert', email: '', url: ''}
+      {name: 'Jon Schlinkert'}
     );
   });
 
@@ -98,7 +90,7 @@ describe('author:', function() {
     var fixture = '<jon@foo.email>';
     assert.deepEqual(
       author(fixture),
-      {name: '', email: 'jon@foo.email', url: ''}
+      {email: 'jon@foo.email'}
     );
   });
 
@@ -106,7 +98,7 @@ describe('author:', function() {
     var fixture = '(https://github.com/jonschlinkert)';
     assert.deepEqual(
       author(fixture),
-      {name: '', email: '', url: 'https://github.com/jonschlinkert'}
+      {url: 'https://github.com/jonschlinkert'}
     );
   });
 });

--- a/test.js
+++ b/test.js
@@ -18,29 +18,58 @@ describe('author:', function() {
 
   it('should return a parsed author object', function() {
     var fixture = 'Jon Schlinkert <jon@foo.email> (https://github.com/jonschlinkert)';
-    assert.deepEqual(author(fixture), {name: 'Jon Schlinkert', email: 'jon@foo.email', url: 'https://github.com/jonschlinkert'});
+    assert.deepEqual(
+      author(fixture),
+      {
+        name: 'Jon Schlinkert',
+        email: 'jon@foo.email',
+        url: 'https://github.com/jonschlinkert'
+      }
+    );
   });
 
   it('should return name and email only', function() {
     var fixture = 'Jon Schlinkert (https://github.com/jonschlinkert)';
-    assert.deepEqual(author(fixture), {name: 'Jon Schlinkert', email: '', url: 'https://github.com/jonschlinkert'});
+    assert.deepEqual(
+      author(fixture),
+      {
+        name: 'Jon Schlinkert',
+        email: '',
+        url: 'https://github.com/jonschlinkert'
+      }
+    );
   });
 
   it('should return mixed properties', function() {
     var fixture = 'Jon Schlinkert ';
-    assert.deepEqual(author(fixture), {name: 'Jon Schlinkert', email: '', url: ''});
+    assert.deepEqual(
+      author(fixture),
+      {name: 'Jon Schlinkert', email: '', url: ''}
+    );
   });
 
   it('should handle empty url placeholders', function() {
     assert.deepEqual(author(' ()'), {name: '', email: '', url: ''});
-    assert.deepEqual(author('Jon Schlinkert ()'), {name: 'Jon Schlinkert', email: '', url: ''});
-    assert.deepEqual(author('<jon.schlinkert@sellside.com> ()'), {name: '', email: 'jon.schlinkert@sellside.com', url: ''});
+    assert.deepEqual(
+      author('Jon Schlinkert ()'),
+      {name: 'Jon Schlinkert', email: '', url: ''}
+    );
+    assert.deepEqual(
+      author('<jon.schlinkert@sellside.com> ()'),
+      {name: '', email: 'jon.schlinkert@sellside.com', url: ''}
+    );
   });
 
   it('should handle empty email placeholders', function() {
     assert.deepEqual(author('<>'), {name: '', email: '', url: ''});
-    assert.deepEqual(author('Jon Schlinkert <>'), {name: 'Jon Schlinkert', email: '', url: ''});
-    assert.deepEqual(author('<> (https://github.com/jonschlinkert)'), {name: '', email: '', url: 'https://github.com/jonschlinkert'});
+    assert.deepEqual(
+      author('Jon Schlinkert <>'),
+      {name: 'Jon Schlinkert', email: '', url: ''}
+    );
+    assert.deepEqual(
+      author('<> (https://github.com/jonschlinkert)'),
+      {name: '', email: '', url: 'https://github.com/jonschlinkert'}
+    );
   });
 
   it('should handle empty email and url placeholders', function() {
@@ -49,20 +78,36 @@ describe('author:', function() {
 
   it('should return mixed properties', function() {
     var fixture = '<jon@foo.email> (https://github.com/jonschlinkert)';
-    assert.deepEqual(author(fixture), {name: '', email: 'jon@foo.email', url: 'https://github.com/jonschlinkert'});
+    assert.deepEqual(
+      author(fixture),
+      {
+        name: '',
+        email: 'jon@foo.email',
+        url: 'https://github.com/jonschlinkert'
+      }
+    );
   });
 
   it('should return name only', function() {
-    assert.deepEqual(author('Jon Schlinkert'), {name: 'Jon Schlinkert', email: '', url: ''});
+    assert.deepEqual(
+      author('Jon Schlinkert'),
+      {name: 'Jon Schlinkert', email: '', url: ''}
+    );
   });
 
   it('should return email only', function() {
     var fixture = '<jon@foo.email>';
-    assert.deepEqual(author(fixture), {name: '', email: 'jon@foo.email', url: ''});
+    assert.deepEqual(
+      author(fixture),
+      {name: '', email: 'jon@foo.email', url: ''}
+    );
   });
 
   it('should return url only', function() {
     var fixture = '(https://github.com/jonschlinkert)';
-    assert.deepEqual(author(fixture), {name: '', email: '', url: 'https://github.com/jonschlinkert'});
+    assert.deepEqual(
+      author(fixture),
+      {name: '', email: '', url: 'https://github.com/jonschlinkert'}
+    );
   });
 });

--- a/test.js
+++ b/test.js
@@ -79,6 +79,14 @@ describe('author:', function() {
     );
   });
 
+  it('should handle misordered properties', function() {
+    var fixture = '(https://github.com/jonschlinkert) <jon@foo.email>';
+    assert.deepEqual(
+      author(fixture),
+      {email: 'jon@foo.email', url: 'https://github.com/jonschlinkert'}
+    );
+  });
+
   it('should return name only', function() {
     assert.deepEqual(
       author('Jon Schlinkert'),

--- a/test.js
+++ b/test.js
@@ -40,10 +40,9 @@ describe('author:', function() {
     );
   });
 
-  it('should return mixed properties', function() {
-    var fixture = 'Jon Schlinkert ';
+  it('should handle trailing whitespace', function() {
     assert.deepEqual(
-      author(fixture),
+      author('Jon Schlinkert '),
       {name: 'Jon Schlinkert', email: '', url: ''}
     );
   });
@@ -76,7 +75,7 @@ describe('author:', function() {
     assert.deepEqual(author('<> ()'), {name: '', email: '', url: ''});
   });
 
-  it('should return mixed properties', function() {
+  it('should handle missing name property', function() {
     var fixture = '<jon@foo.email> (https://github.com/jonschlinkert)';
     assert.deepEqual(
       author(fixture),


### PR DESCRIPTION
With these changes, parse-author is fully compatible with npm author strings (as they are handled in [normalize-package-data](https://github.com/npm/normalize-package-data)).

This PR will require a major version bump (bringing us to `1.0.0`), and once that is published I'll try a PR to use this within npm too.
